### PR TITLE
Changing a default heading from h3 to h2

### DIFF
--- a/_php_interior_1col.tmpl
+++ b/_php_interior_1col.tmpl
@@ -43,7 +43,8 @@
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/1column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/_php_interior_2col.tmpl
+++ b/_php_interior_2col.tmpl
@@ -38,14 +38,16 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/_php_interior_3col.tmpl
+++ b/_php_interior_3col.tmpl
@@ -38,21 +38,24 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>
 		<column_three>
 		<!-- com.omniupdate.div  label="column_three"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor  csspath="/includes/ou/editor/3column/column_three.css"  cssmenu="/includes/ou/editor/content.txt"  width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
         <!-- /com.omniupdate.div -->
 		</column_three>

--- a/_php_sub_2col.tmpl
+++ b/_php_sub_2col.tmpl
@@ -45,14 +45,16 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/_php_sub_3col.tmpl
+++ b/_php_sub_3col.tmpl
@@ -45,21 +45,24 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>
 		<column_three>
 		<!-- com.omniupdate.div  label="column_three"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor  csspath="/includes/ou/editor/3column/column_three.css"  cssmenu="/includes/ou/editor/content.txt"  width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_three>

--- a/_php_top-level_interior_1col.tmpl
+++ b/_php_top-level_interior_1col.tmpl
@@ -43,7 +43,8 @@
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/1column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/_sidenav.tmpl
+++ b/_sidenav.tmpl
@@ -1,2 +1,2 @@
-<!-- com.omniupdate.editor csspath="/sjsu/_resources/ou/editor/standard-sidenav.css" cssmenu="/sjsu/_resources/ou/editor/standard-sidenav.txt" width="798" -->
+<!-- com.omniupdate.editor csspath="/sjsuhome/assets/ou/editor/sidenav.css" cssmenu="/sjsuhome/assets/ou/editor/sidenav.txt" width="955" -->
 

--- a/_test_sub_2col.tmpl
+++ b/_test_sub_2col.tmpl
@@ -43,14 +43,16 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/interior_1col.tmpl
+++ b/interior_1col.tmpl
@@ -43,7 +43,8 @@
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/1column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/interior_1col_full.tmpl
+++ b/interior_1col_full.tmpl
@@ -46,7 +46,8 @@
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/1column/fullwidth.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/interior_2col.tmpl
+++ b/interior_2col.tmpl
@@ -38,14 +38,16 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/interior_3col.tmpl
+++ b/interior_3col.tmpl
@@ -38,21 +38,24 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>
 		<column_three>
 		<!-- com.omniupdate.div  label="column_three"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor  csspath="/includes/ou/editor/3column/column_three.css"  cssmenu="/includes/ou/editor/content.txt"  width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
         <!-- /com.omniupdate.div -->
 		</column_three>

--- a/newhome.tmpl
+++ b/newhome.tmpl
@@ -42,21 +42,24 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>
 		<column_three>
 		<!-- com.omniupdate.div  label="column_three"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor  csspath="/includes/ou/editor/3column/column_three.css"  cssmenu="/includes/ou/editor/content.txt"  width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
         <!-- /com.omniupdate.div -->
 		</column_three>

--- a/sub_2col.tmpl
+++ b/sub_2col.tmpl
@@ -45,14 +45,16 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/sub_3col.tmpl
+++ b/sub_3col.tmpl
@@ -45,21 +45,24 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>
 		<column_three>
 		<!-- com.omniupdate.div  label="column_three"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor  csspath="/includes/ou/editor/3column/column_three.css"  cssmenu="/includes/ou/editor/content.txt"  width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_three>

--- a/top-level_interior_1col.tmpl
+++ b/top-level_interior_1col.tmpl
@@ -43,7 +43,8 @@
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/1column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/top-level_interior_2col.tmpl
+++ b/top-level_interior_2col.tmpl
@@ -38,14 +38,16 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/2column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>

--- a/top-level_interior_3col.tmpl
+++ b/top-level_interior_3col.tmpl
@@ -38,21 +38,24 @@
 		<column_one>
 		<!-- com.omniupdate.div  label="column_one"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_one.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_one>
 		<column_two>
 		<!-- com.omniupdate.div  label="column_two"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor csspath="/includes/ou/editor/3column/column_two.css" cssmenu="/includes/ou/editor/content.txt" width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
 		<!-- /com.omniupdate.div -->
 		</column_two>
 		<column_three>
 		<!-- com.omniupdate.div  label="column_three"  group="Everyone"  button="707"  break="break" -->
 		<!-- com.omniupdate.editor  csspath="/includes/ou/editor/3column/column_three.css"  cssmenu="/includes/ou/editor/content.txt"  width="955" -->
-		<h3>Lorem ipsum dolor</h3>
+		
+<h2>Lorem ipsum dolor</h2>
 		<p>Integer vel elit at lorem dictum fringilla id eget lectus. Nam ut mi nibh, id viverra tortor. Ut laoreet, sapien quis semper placerat, nulla nisi molestie est, pretium tincidunt massa tellus ac augue. Mauris faucibus, nisl id vulputate consequat, purus lorem sagittis nisi, ut ornare orci sapien auctor tellus. Praesent at nulla ut mi rutrum semper eu in arcu. Nulla viverra dignissim sem, quis vehicula justo malesuada a. Phasellus pellentesque egestas posuere. Proin ornare tempus felis ultricies molestie. Vivamus arcu lectus, posuere id lobortis volutpat, adipiscing sed nibh. </p>
         <!-- /com.omniupdate.div -->
 		</column_three>


### PR DESCRIPTION
The web typography update modified the standardized practice of which
headings (H1, H2, etc) are used on templated pages.

However, the default "lorem ipsum" text on page templates uses H3 as the
default instead of the new H2. For users who don't modify it themselves,
this means that the headings become inconsistent on published pages,
inhibiting accessibility and best practices.

The lorem ipsum headings need to be modified to H2 in the TMPL files.
